### PR TITLE
Update Makefile to prevent "No rule to make target" error

### DIFF
--- a/plancode/Makefile
+++ b/plancode/Makefile
@@ -14,7 +14,7 @@ planning/nyearplan.class:planning/nyearplan.java planning/csvfilereader.class
 plan.txt: model.lp
 	lp_solve <model.lp|sort >plan.txt
 	
-model.lp:planning/nyearplan.class flows.csv cap.csv dep.csv labtarg.csv makefile
+model.lp:planning/nyearplan.class flows.csv cap.csv dep.csv labtarg.csv Makefile
 	java planning.nyearplan flows.csv cap.csv dep.csv labtarg.csv   >model.lp
 	
 	


### PR DESCRIPTION
The Makefile had a misspelling that created an error when running make.